### PR TITLE
Nuevos menus

### DIFF
--- a/src/components/kpis/KpiItem.vue
+++ b/src/components/kpis/KpiItem.vue
@@ -2,7 +2,8 @@
   <div>
     <section>
       <el-card shadow="hover">
-        <section class="actions nav">
+
+        <section class="actions nav" v-if="!showingRegisters">
           <el-button
             :disabled="!!!prevKpi"
             icon="el-icon-back"
@@ -94,7 +95,8 @@
       </el-card>
     </section>
 
-    <section>
+    <!-- Only show actions buttons if we are not in a registers view -->
+    <section v-if="!showingRegisters">
       <el-card shadow="hover">
         <div class="actions">
           <base-badge
@@ -172,6 +174,9 @@ export default {
       );
       return allKpis[--selectedKpiIndex];
     },
+    showingRegisters(){
+      return this.$route.path.includes('registers')
+    },
   },
 
   methods: {
@@ -195,6 +200,7 @@ export default {
         (kpi) => kpi.id == this.id
       );
     },
+
   },
   created() {
     // Take id from props

--- a/src/components/layout/TheHeader.vue
+++ b/src/components/layout/TheHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="header">
+  <nav>
     <el-menu
       :default-active="$route.path"
       class="el-menu-demo"
@@ -11,23 +11,19 @@
         <template #title>Home</template>
       </el-menu-item>
 
-      <el-submenu index="/kpis">
-        <template #title>
-          <i class="el-icon-s-marketing"></i>
-          <span>Indicadores</span>
-        </template>
-        <el-menu-item index="/kpis/create">Nuevo KPI</el-menu-item>
+      <el-menu-item index="/kpis/create">
+        <i class="el-icon-circle-plus"></i>
+        <template #title>Nuevo indicador</template>
+      </el-menu-item>
 
-        <el-submenu index="/kpis">
-          <template #title>Listado KPIs</template>
-          <el-menu-item index="/kpis">KPIs activos</el-menu-item>
-          <el-menu-item index="/kpis/deleted">KPIs eliminados</el-menu-item>
-        </el-submenu>
-      </el-submenu>
-
-      <el-menu-item index="/register">
+      <el-menu-item index="/kpis">
         <i class="el-icon-s-data"></i>
-        <template #title>Registros (Raúl)</template>
+        <template #title>Indicadores activos</template>
+      </el-menu-item>
+
+      <el-menu-item index="/kpis/deleted">
+        <i class="el-icon-delete"></i>
+        <template #title>Papelera de KPIs</template>
       </el-menu-item>
 
       <el-menu-item index="/auth" disabled>
@@ -40,5 +36,17 @@
         <template #title>Administrar atributos</template>
       </el-menu-item>
     </el-menu>
-  </section>
+  </nav>
 </template>
+
+
+<style lang="scss" scoped>
+nav {
+  overflow: hidden;
+  overflow-x: auto;
+
+  ul {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/layout/TheSidebar.vue
+++ b/src/components/layout/TheSidebar.vue
@@ -12,25 +12,19 @@
         <template #title>Home</template>
       </el-menu-item>
 
-      <el-submenu index="/kpis">
-        <template #title>
-          <i class="el-icon-s-marketing"></i>
-          <span>Indicadores</span>
-        </template>
+     <el-menu-item index="/kpis/create">
+        <i class="el-icon-circle-plus"></i>
+        <template #title>Nuevo indicador</template>
+      </el-menu-item>
 
-        <el-menu-item-group title="Creación">
-          <el-menu-item index="/kpis/create">Nuevo KPI</el-menu-item>
-        </el-menu-item-group>
-
-        <el-menu-item-group title="Listados">
-          <el-menu-item index="/kpis">KPIs activos</el-menu-item>
-          <el-menu-item index="/kpis/deleted">KPIs eliminados</el-menu-item>
-        </el-menu-item-group>
-      </el-submenu>
-
-      <el-menu-item index="/register">
+      <el-menu-item index="/kpis">
         <i class="el-icon-s-data"></i>
-        <template #title>Registros (Raúl)</template>
+        <template #title>Indicadores activos</template>
+      </el-menu-item>
+
+      <el-menu-item index="/kpis/deleted">
+        <i class="el-icon-delete"></i>
+        <template #title>Papelera de KPIs</template>
       </el-menu-item>
 
       <el-menu-item index="/auth" disabled>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,23 +3,24 @@
     <h1>Gestión de indicadores</h1>
 
     <section class="cards">
+      
       <transition name="register" appear>
         <el-card
           key="register"
           shadow="hover"
-          @click="$router.push('/register')"
+          @click="$router.push('/kpis/create')"
         >
-          <i class="el-icon-s-data"></i>
+          <i class="el-icon-circle-plus"></i>
           <br /><br />
-          <span>Registros de valores</span>
+          <span>Nuevo indicador</span>
         </el-card>
       </transition>
 
       <transition name="kpis" appear>
         <el-card key="kpis" shadow="hover" @click="$router.push('/kpis')">
-          <i class="el-icon-s-marketing"></i>
+          <i class="el-icon-s-data"></i>
           <br /><br />
-          <span>Indicadores</span>
+          <span>Indicadores activos</span>
         </el-card>
       </transition>
 


### PR DESCRIPTION
Reestructuracion de los menus: eliminación de menu register (puesto que los registros siempre estarán anclados / relacionados a un KPI especifico).

TheHeader ahora tiene mayor compatibilidad para vistas móviles, mostrando todo el contenido en una sola linea horizontal a través de la cual se puede navegar con scroll horizontal

Además, KPI Item solo muestra botones de acción cuando está en una ruta no relacionada con registros